### PR TITLE
usethis::use_pkgdown_pages()

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,7 @@
 ^data-raw$
 ^README\.Rmd$
 ^\.github$
+^vignettes/articles$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,46 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,3 +28,4 @@ Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
+URL: https://2degreesinvesting.github.io/tilt.company.match/

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,4 @@
+url: https://2degreesinvesting.github.io/tilt.company.match/
+template:
+  bootstrap: 5
+

--- a/man/tilt.company.match-package.Rd
+++ b/man/tilt.company.match-package.Rd
@@ -8,6 +8,13 @@
 \description{
 Package holds helpers for company matching in the tilt-project. For details please refer to README.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://2degreesinvesting.github.io/tilt.company.match/}
+}
+
+}
 \author{
 \strong{Maintainer}: Mirja Hollmann \email{mirja@2degrees-investing.org}
 


### PR DESCRIPTION
This PR creates a website with online access to README, helpfiles for functions and data, and any other articles we choose. 

Website: https://2degreesinvesting.github.io/tilt.company.match/

It's low risk:

* Everything in the website is already public in the repo.
* It touches no production code.

Given it's low risk and time constraints, I'll merge it without review.