### PR TITLE
Explanation on not automatically approving the unique matches

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -251,9 +251,14 @@ loanbook_with_candidates_and_dist_and_suggestion <- loanbook_with_candidates_and
 knitr::kable(loanbook_with_candidates_and_dist_and_suggestion)
 ```
 
-**Note**: even a match of 1 in the same postcode can in rare cases be a
-False positive, compare e.g. company 4 ("Peasant Paul") in the example
-data.
+**Notes**: 
+
+-   Even a match of 1 in the same postcode can in rare cases be a False positive, 
+    compare e.g. company 4 ("Peasant Paul") in the example data.
+-   We do not want to automatically approve unique matches because there may be 
+    few cases where multiple companies in the same ZIP code have the same name. 
+    In these cases, additional information (for example, the sector, street name,
+    or main activity etc.) can help to make a final decision.
 
 ### Check matching process
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ of the data set and report them to the user.
 Here, the loanbook data set does not have any NAs.
 
 ``` r
-abort_if_incomplete(demo_loanbook)
+#abort_if_incomplete(demo_loanbook)
 ```
 
 There are some columns (currently **id** and **company_name**) on which
@@ -144,6 +144,7 @@ missing_non_crucial <- demo_loanbook %>%
 
 missing_non_crucial %>% 
   abort_if_incomplete(non_nullable_cols = c("id", "company_name"))
+#> Error in abort_if_incomplete(., non_nullable_cols = c("id", "company_name")): could not find function "abort_if_incomplete"
 
 # missings on a crucial column
 missing_crucial <- demo_loanbook %>% 
@@ -151,9 +152,7 @@ missing_crucial <- demo_loanbook %>%
 
 missing_crucial %>% 
   abort_if_incomplete(non_nullable_cols = c("id", "company_name"))
-#> Error in `abort_if_incomplete()`:
-#> ! Non-nullable columns must not have `NA`s.
-#> ✖ Columns to review: company_name
+#> Error in abort_if_incomplete(., non_nullable_cols = c("id", "company_name")): could not find function "abort_if_incomplete"
 ```
 
 ### Preprocessing
@@ -331,9 +330,15 @@ knitr::kable(loanbook_with_candidates_and_dist_and_suggestion)
 |  10 | John Meier’s Groceries | 55555    | germany | Y         | johnmeiersgroceries |      NA | NA                           | NA             | NA                    |         NA | NA            | NA           |
 |  11 | John Meier’s Groceries | 55555    | norway  | Y         | johnmeiersgroceries |      NA | NA                           | NA             | NA                    |         NA | NA            | NA           |
 
-**Note**: even a match of 1 in the same postcode can in rare cases be a
-False positive, compare e.g. company 4 (“Peasant Paul”) in the example
-data.
+**Notes**:
+
+- Even a match of 1 in the same postcode can in rare cases be a False
+  positive, compare e.g. company 4 (“Peasant Paul”) in the example data.
+- We do not want to automatically approve unique matches because there
+  may be few cases where multiple companies in the same ZIP code have
+  the same name. In these cases, additional information (for example,
+  the sector, street name, or main activity etc.) can help to make a
+  final decision.
 
 ### Check matching process
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ For an example compare demo data below.
 
 ``` r
 library(tilt.company.match)
+#> Loading required package: stringdist
 knitr::kable(head(demo_loanbook))
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ For an example compare demo data below.
 
 ``` r
 library(tilt.company.match)
-#> Loading required package: stringdist
 knitr::kable(head(demo_loanbook))
 ```
 
@@ -127,7 +126,7 @@ of the data set and report them to the user.
 Here, the loanbook data set does not have any NAs.
 
 ``` r
-#abort_if_incomplete(demo_loanbook)
+abort_if_incomplete(demo_loanbook)
 ```
 
 There are some columns (currently **id** and **company_name**) on which
@@ -144,7 +143,6 @@ missing_non_crucial <- demo_loanbook %>%
 
 missing_non_crucial %>% 
   abort_if_incomplete(non_nullable_cols = c("id", "company_name"))
-#> Error in abort_if_incomplete(., non_nullable_cols = c("id", "company_name")): could not find function "abort_if_incomplete"
 
 # missings on a crucial column
 missing_crucial <- demo_loanbook %>% 
@@ -152,7 +150,9 @@ missing_crucial <- demo_loanbook %>%
 
 missing_crucial %>% 
   abort_if_incomplete(non_nullable_cols = c("id", "company_name"))
-#> Error in abort_if_incomplete(., non_nullable_cols = c("id", "company_name")): could not find function "abort_if_incomplete"
+#> Error in `abort_if_incomplete()`:
+#> ! Non-nullable columns must not have `NA`s.
+#> ✖ Columns to review: company_name
 ```
 
 ### Preprocessing
@@ -207,8 +207,8 @@ loanbook_with_candidates <- loanbook %>%
   dplyr::left_join(tilt, by = c("country", "postcode"), suffix = c("", "_tilt"))
 #> Warning in dplyr::left_join(., tilt, by = c("country", "postcode"), suffix = c("", : Each row in `x` is expected to match at most 1 row in `y`.
 #> ℹ Row 1 of `x` matches multiple rows.
-#> ℹ If multiple matches are expected, set `multiple = "all"` to silence this
-#>   warning.
+#> ℹ If multiple matches are expected, set `multiple = "all"`
+#>   to silence this warning.
 
 knitr::kable(head(loanbook_with_candidates))
 ```
@@ -384,12 +384,13 @@ companies in the loanbook for which no match was selected or found.
 
 ``` r
 not_matched <- report_no_matches(loanbook, manually_matched)
-#> Joining with `by = join_by(id, company_name, postcode, country, misc_info,
-#> company_alias)`
-#> Companies not matched in the loanbook by the tilt data set: Peasant Paul Bread
-#> Bakers Limited Screwdriver Experts Screwdriver Expert John Meier's Groceries
-#> John Meier's Groceries John Meier's Groceries ℹ Did you match these companies
-#> manually correctly ?
+#> Joining with `by = join_by(id, company_name, postcode,
+#> country, misc_info, company_alias)`
+#> Companies not matched in the loanbook by the tilt data set:
+#> Peasant Paul Bread Bakers Limited Screwdriver Experts
+#> Screwdriver Expert John Meier's Groceries John Meier's
+#> Groceries John Meier's Groceries ℹ Did you match these
+#> companies manually correctly ?
 
 knitr::kable(not_matched)
 ```

--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ loanbook_with_candidates <- loanbook %>%
   dplyr::left_join(tilt, by = c("country", "postcode"), suffix = c("", "_tilt"))
 #> Warning in dplyr::left_join(., tilt, by = c("country", "postcode"), suffix = c("", : Each row in `x` is expected to match at most 1 row in `y`.
 #> ℹ Row 1 of `x` matches multiple rows.
-#> ℹ If multiple matches are expected, set `multiple = "all"`
-#>   to silence this warning.
+#> ℹ If multiple matches are expected, set `multiple = "all"` to silence this
+#>   warning.
 
 knitr::kable(head(loanbook_with_candidates))
 ```
@@ -385,13 +385,12 @@ companies in the loanbook for which no match was selected or found.
 
 ``` r
 not_matched <- report_no_matches(loanbook, manually_matched)
-#> Joining with `by = join_by(id, company_name, postcode,
-#> country, misc_info, company_alias)`
-#> Companies not matched in the loanbook by the tilt data set:
-#> Peasant Paul Bread Bakers Limited Screwdriver Experts
-#> Screwdriver Expert John Meier's Groceries John Meier's
-#> Groceries John Meier's Groceries ℹ Did you match these
-#> companies manually correctly ?
+#> Joining with `by = join_by(id, company_name, postcode, country, misc_info,
+#> company_alias)`
+#> Companies not matched in the loanbook by the tilt data set: Peasant Paul Bread
+#> Bakers Limited Screwdriver Experts Screwdriver Expert John Meier's Groceries
+#> John Meier's Groceries John Meier's Groceries ℹ Did you match these companies
+#> manually correctly ?
 
 knitr::kable(not_matched)
 ```


### PR DESCRIPTION
Closes #41

Edited: @kalashsinghal note the keyword `Closes #issue-number` closes the `issue-number` automatically when this PR is merged. 

https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests