### PR TITLE
Fix call to duplicated() in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -275,7 +275,7 @@ highest_matches_per_company_above_thresh <- highest_matches_per_company %>%
   dplyr::filter(string_sim > threshold)
 
 highest_matches_per_company_above_thresh_wo_duplicates <- highest_matches_per_company_above_thresh %>%
-  dplyr::mutate(duplicates = any(duplicated(company_name, postcode))) %>%
+  dplyr::mutate(duplicates = any(duplicated(paste(company_name, postcode)))) %>%
   dplyr::filter(duplicates == FALSE) %>%
   dplyr::select(id, id_tilt) %>%
   dplyr::mutate(suggest_match = TRUE)

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ highest_matches_per_company_above_thresh <- highest_matches_per_company %>%
   dplyr::filter(string_sim > threshold)
 
 highest_matches_per_company_above_thresh_wo_duplicates <- highest_matches_per_company_above_thresh %>%
-  dplyr::mutate(duplicates = any(duplicated(company_name, postcode))) %>%
+  dplyr::mutate(duplicates = any(duplicated(paste(company_name, postcode)))) %>%
   dplyr::filter(duplicates == FALSE) %>%
   dplyr::select(id, id_tilt) %>%
   dplyr::mutate(suggest_match = TRUE)


### PR DESCRIPTION
Relates to #56
This fix was implemented in Get started but had not yet been ported to README. This PR does just that.