### PR TITLE
Handle weird encoding

### DIFF
--- a/R/to_alias.R
+++ b/R/to_alias.R
@@ -75,12 +75,12 @@ to_alias <- function(x,
                      from_to = NULL,
                      ownership = NULL,
                      remove_ownership = FALSE) {
-  # lowercase
-  out <- tolower(x)
-
+  out <- x
   # base latin characters
   out <- stringi::stri_trans_general(out, "any-latin")
   out <- stringi::stri_trans_general(out, "latin-ascii")
+  # lowercase
+  out <- tolower(out)
 
   # symbols
   out <- purrr::reduce(get_sym_replace(), replace_abbrev, fixed = TRUE, .init = out)

--- a/tests/testthat/test-to_alias.R
+++ b/tests/testthat/test-to_alias.R
@@ -272,3 +272,8 @@ test_that("get_ownership_type() is equal to its legacy in pacta", {
     character(0)
   )
 })
+
+test_that("handles weird encoding", {
+  expect_no_error(to_alias("\xfc"))
+})
+


### PR DESCRIPTION
`to_alias()` fails with weird encoding because it deals with encoding AFTER calling `tolower()`. The solution is to first handle encoding then do anything else.

``` r
sanitize <- function(x) {
  x <- stringi::stri_trans_general(x, "any-latin")
  x <- stringi::stri_trans_general(x, "latin-ascii")
  x
}

x <- "\xfc"
# This is what it looks like
cat(x)
#> <fc>

# Fails
x |> tolower()
#> Error in tolower(x): invalid multibyte string 1

# Passes
x |> sanitize() |> tolower()
#> [1] "�"
```

<sup>Created on 2023-02-22 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

--

Thanks @Tilmon 
